### PR TITLE
Fix incomplete regex match

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ class ElmRootDefender {
                 `var bodyNode = _VirtualDom_doc.getElementById('${this.elmRootId}');`
             )
             .replace(
-                /var nextNode = _VirtualDom_node\('body'\)\(_List_Nil\)\(doc\.(\w+)\);/gi,
+                /var nextNode = _VirtualDom_node\('body'\)\(_List_Nil\)\(doc\.([\w\$]+)\);/gi,
                 (match, docBodyIdentifier) => `var nextNode = _VirtualDom_node('div')(_List_Nil)(doc.${docBodyIdentifier})`
             )
     }


### PR DESCRIPTION
I was running into a problem where the 2nd regex in this script was never being matched. That happened because `$` is a valid character in variable names, which this regex doesn't match. This PR fixes that!